### PR TITLE
Fix the java version verification regex

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ if [ ! -x "${JAVA}" ]; then
 else
    	# export JAVA_VERSION
 	JAVA_VERSION=`java -version 2>&1 |awk 'NR==1{ gsub(/"/,""); print $3 }'`
-	JAVA_VER=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
+	JAVA_VER=$(java -version 2>&1 | sed -n ';s/.* version "\([^.]*\)\.\([^.]*\)\..*$/\1\2/p;')
 
 	if [ "$JAVA_VER" -ge 17 ]; then
 	 	echo $JAVA_VERSION


### PR DESCRIPTION
Fix the `JAVA_VER` regular expression to support also OpenJDK
and ensures that only the first two `.` of the version number
are taken into account.